### PR TITLE
JOB-68920 Add extra_data_package_arn option to aws devicefarm schedule run

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -10,6 +10,7 @@ app:
   - DEVICE_FARM_PROJECT: $DEVICE_FARM_PROJECT
   - BILLING_METHOD: $BILLING_METHOD
   - LOCALE: $LOCALE
+  - EXTRA_DATA_PACKAGE_ARN: $EXTRA_DATA_PACKAGE_ARN
   - TEST_PACKAGE_NAME: $TEST_PACKAGE_NAME
   - TEST_TYPE: $TEST_TYPE
   - FILTER: $FILTER
@@ -33,6 +34,7 @@ workflows:
         - device_farm_project: $DEVICE_FARM_PROJECT
         - billing_method: $BILLING_METHOD
         - locale: $LOCALE
+        - extra_data_package_arn: $EXTRA_DATA_PACKAGE_ARN
         - test_package_name: $TEST_PACKAGE_NAME
         - test_type: $TEST_TYPE
         - filter: $FILTER

--- a/step.sh
+++ b/step.sh
@@ -211,7 +211,7 @@ function device_farm_run {
     # Start run
     local run_params=(--project-arn="$device_farm_project")
     run_params+=(--device-pool-arn="$device_pool")
-    run_params+=(--configuration="{\"billingMethod\": \"${billing_method}\", \"locale\": \"${locale}\"}")
+    run_params+=(--configuration="{\"billingMethod\": \"${billing_method}\", \"locale\": \"${locale}\", \"extraDataPackageArn\": \"${extra_data_package_arn}\"}")
     run_params+=(--app-arn="$app_arn")
     run_params+=(--output=json)
 
@@ -324,6 +324,7 @@ echo_details "* test_type: $test_type"
 echo_details "* filter: $filter"
 echo_details "* test_spec: $test_spec"
 echo_details "* billing_method: $billing_method"
+echo_details "* extra_data_package_arn: $extra_data_package_arn"
 echo_details "* locale: $locale"
 echo_details "* platform: $platform"
 echo_details "* ipa_path: $ipa_path"

--- a/step.yml
+++ b/step.yml
@@ -116,6 +116,12 @@ inputs:
           - "uk_UA"
           - "vi_VN"
       is_required: false
+  - extra_data_package_arn: ""
+    opts:
+      title: "Extra data package ARN"
+      summary: ""
+      description: "The ARN of the extra data for the run. The extra data is a .zip file that AWS Device Farm extracts to external data for Android or the app's sandbox for iOS."
+      is_required: false
   - test_package_name: ""
     opts:
       title: "Test Package Filename"


### PR DESCRIPTION
To run Appium on AWS, we need to use the prebuiltWDA option. To use this, we need to use a WDA (WebDriverAgent) already installed on device. 

This field `extraDataPackageArn` is the one we inform the WDA ARN. So basically, I'm adding a new optional field to inform when we need to use additional data on a run when dealing with iOS (but can be used with Android too).

Reference: 

https://docs.aws.amazon.com/devicefarm/latest/APIReference/API_ScheduleRunConfiguration.html#devicefarm-Type-ScheduleRunConfiguration-extraDataPackageArn