### PR TITLE
JOB-125889

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Deploys app to device farm and starts a test run with a preconfigured test packa
 - `ios_pool` - Device Farm iOS Device Pool ARN. Required for iOS runs. ARNs can be obtained using the AWS CLI `devicefarm list-device-pools` command.
 
 ### Android-specific Inputs
-- `apk_path` - APK file path. Required for Android runs when `apk_package_name` is not provided. Default: `$BITRISE_SIGNED_APK_PATH`
-- `apk_package_name` - Filename of APK package to use for testing. This should be a filename (not a path) that matches the name of the APK bundle previously uploaded with the [aws-device-farm-file-deploy](https://github.com/peartherapeutics/bitrise-aws-device-farm-file-deploy) step. The most recently uploaded package with this name will be used. If provided, this takes precedence over `apk_path`.
+- `apk_path` - APK file path. Required for Android runs when `apk_name` is not provided. Default: `$BITRISE_SIGNED_APK_PATH`
+- `apk_name` - Filename of APK package to use for testing. This should be a filename (not a path) that matches the name of the APK bundle previously uploaded with the [aws-device-farm-file-deploy](https://github.com/peartherapeutics/bitrise-aws-device-farm-file-deploy) step. The most recently uploaded package with this name will be used. If provided, this takes precedence over `apk_path`.
 - `android_pool` - Device Farm Android Device Pool ARN. Required for Android runs. ARNs can be obtained using the AWS CLI `devicefarm list-device-pools` command.
 
 ## Outputs
@@ -52,7 +52,7 @@ This step supports two approaches for providing app packages (IPA/APK files):
 
 ### Package Name Approach (New)
 - Use `ipa_package_name` for iOS apps
-- Use `apk_package_name` for Android apps
+- Use `apk_name` for Android apps
 - The step will look up the most recently uploaded package with the specified name
 - No upload is performed, saving time and bandwidth
 - Requires packages to be previously uploaded using the [aws-device-farm-file-deploy](https://github.com/peartherapeutics/bitrise-aws-device-farm-file-deploy) step
@@ -110,7 +110,7 @@ envs:
      1. An Amazon device farm project must be set up in the target region, and its ARN must be specified in the `device_farm_project` input
      1. If `platform` input is...
        1. ... set to `ios`, then `ios_pool` must be set to the ARN of an iOS device pool and either `ipa_path` or `ipa_package_name` must be set
-       1. ... set to `android`, then `android_pool` must be set to the ARN of an Android device pool and either `apk_path` or `apk_package_name` must be set
+       1. ... set to `android`, then `android_pool` must be set to the ARN of an Android device pool and either `apk_path` or `apk_name` must be set
        1. ... set to `ios+android`, then all of the above inputs must be set
   - see `step.yml` for more info on obtaining ARNs
 

--- a/step.sh
+++ b/step.sh
@@ -96,8 +96,8 @@ function validate_ios_inputs {
 }
 
 function validate_android_inputs {
-    if [[ -n "$apk_package_name" ]]; then
-        validate_required_input "apk_package_name" "${apk_package_name}"
+    if [[ -n "$apk_name" ]]; then
+        validate_required_input "apk_name" "${apk_name}"
     else
         validate_required_input "apk_path" "${apk_path}"
     fi
@@ -118,10 +118,10 @@ function get_test_package_arn {
 function get_apk_package_arn {
     # Get most recent Android APK ARN
     set +o errexit
-    validate_required_variable "apk_package_name" "${apk_package_name}"
-    apk_package_arn=$(set -eu; set -o pipefail; aws devicefarm list-uploads --arn="$device_farm_project" --query="uploads[?name=='${apk_package_name}' && type=='ANDROID_APP'] | max_by(@, &created).arn" --output=json | jq -r .)
+    validate_required_variable "apk_name" "${apk_name}"
+    apk_package_arn=$(set -eu; set -o pipefail; aws devicefarm list-uploads --arn="$device_farm_project" --query="uploads[?name=='${apk_name}' && type=='ANDROID_APP'] | max_by(@, &created).arn" --output=json | jq -r .)
     if [[ "$?" -ne 0 ]]; then
-        echo_fail "Unable to find an Android APK package named '${apk_package_name}' in your device farm project. Please make sure that apk_package_name corresponds to the basename (not the full path) of the APK package which should have been previously uploaded by the aws-file-deploy step. If the APK is too old it may not be found; try re-uploading it. See https://github.com/peartherapeutics/bitrise-aws-device-farm-file-deploy"
+        echo_fail "Unable to find an Android APK package named '${apk_name}' in your device farm project. Please make sure that apk_name corresponds to the basename (not the full path) of the APK package which should have been previously uploaded by the aws-file-deploy step. If the APK is too old it may not be found; try re-uploading it. See https://github.com/peartherapeutics/bitrise-aws-device-farm-file-deploy"
     fi
     set -o errexit
 }
@@ -340,7 +340,7 @@ function device_farm_run_ios {
 }
 
 function device_farm_run_android {
-    if [[ -n "$apk_package_name" ]]; then
+    if [[ -n "$apk_name" ]]; then
         device_farm_run android "$android_pool" "" ANDROID_APP "$apk_package_arn"
     else
         device_farm_run android "$android_pool" "$apk_path" ANDROID_APP ""
@@ -376,7 +376,7 @@ echo_details "* ipa_path: $ipa_path"
 echo_details "* ipa_package_name: $ipa_package_name"
 echo_details "* ios_pool: $ios_pool"
 echo_details "* apk_path: $apk_path"
-echo_details "* apk_package_name: $apk_package_name"
+echo_details "* apk_name: $apk_name"
 echo_details "* android_pool: $android_pool"
 echo_details "* run_name_prefix: $run_name_prefix"
 echo_details "* build_version: $build_version"
@@ -423,7 +423,7 @@ elif [ "$platform" == 'android' ]; then
     validate_android_inputs
     set -o nounset
     get_test_package_arn
-    if [[ -n "$apk_package_name" ]]; then
+    if [[ -n "$apk_name" ]]; then
         get_apk_package_arn
     fi
     device_farm_run_android
@@ -435,7 +435,7 @@ elif [ "$platform" == 'ios+android' ]; then
     if [[ -n "$ipa_package_name" ]]; then
         get_ipa_package_arn
     fi
-    if [[ -n "$apk_package_name" ]]; then
+    if [[ -n "$apk_name" ]]; then
         get_apk_package_arn
     fi
     device_farm_run_ios

--- a/step.yml
+++ b/step.yml
@@ -174,8 +174,8 @@ inputs:
   - apk_path: "$BITRISE_SIGNED_APK_PATH"
     opts:
       title: "APK file path"
-      description: "Required for Android runs when apk_package_name is not provided."
-  - apk_package_name: ""
+      description: "Required for Android runs when apk_name is not provided."
+  - apk_name: ""
     opts:
       title: "APK Package Filename"
       summary: ""


### PR DESCRIPTION
# What's in this PR?

### Why was this PR created?

The original script was made to upload the binary with every run, but now we need to use existing previously uploaded binaries to rerun a test


### Quick summary of the changes you made

I added two new properties for iOS and android to specify a file name that will be looked up similar to how it does it for the test bundle

I also updated the README file to specify the inputs and outputs of the step

## Before

upload a binary to get the application ARN thats needed to triggers a test run

## After

can also specify a name and the latest application ARN is looked by type and name

# QA

Successful run where we found the android app's ARN by name: https://app.bitrise.io/build/99ae35f8-9dd1-4e5e-b5ec-fe07ca76f8b8